### PR TITLE
Dockerize for the Windows folks in the back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+FROM python:3.10-bullseye as poetry-base
+LABEL maintainer="Matt Alioto <malioto@probitytns.com>"
+
+# Python flags from https://bmaingret.github.io/blog/2021-11-15-Docker-and-Poetry
+ENV \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONFAULTHANDLER=1
+ENV POETRY_NO_INTERACTION=1
+
+WORKDIR /
+COPY docker-install-packages.sh .
+RUN chmod +x ./docker-install-packages.sh && ./docker-install-packages.sh
+
+# Install Poetry at pinned version
+ENV POETRY_VERSION=1.2.0
+RUN curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+# Add poetry install location to PATH
+ENV PATH=/root/.local/bin:$PATH
+
+FROM poetry-base as wordle
+LABEL maintainer="Matt Alioto <malioto@probitytns.com>"
+
+ENV APP_HOME app
+
+WORKDIR $APP_HOME
+# Cache deps
+COPY /poetry.lock /pyproject.toml ./
+RUN poetry install --only main 
+
+# Copy code & execute
+COPY ./wordle ./wordle
+#CMD ["/bin/bash"]
+CMD ["poetry", "run", "wordle"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ Enter results of a guess like 'xgxyy', where
 - g: Green (correct)
 - y: Yellow (correct, but misplaced)
 - x: Grey (wrong)
+
+## Running with Docker
+
+On Windows machines, it may be more convenient to run this program using Docker.
+
+With Docker running in the background, run
+
+`docker build -t wordle .`
+
+followed by
+
+`docker run -it wordle`
+
+I would _not_ recommend looking to this Dockerfile for insight, as it is largely copy/pasted from another project.

--- a/docker-install-packages.sh
+++ b/docker-install-packages.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Modified from example at https://pythonspeed.com/articles/system-packages-docker/
+# The goal of this script is to cleanly
+# 1) Grab security updates pertinant to the Docker image from within which this script is called
+# 2) Install cURL, a needed dependency
+# 3) Clean the package cache (etc)
+# in such a way that Docker caching is preserved and unneeded files are never present in any layer of the image
+
+# Bash "strict mode", to help catch problems and bugs in the shell script. Every bash script you write should include this. See
+set -euo pipefail
+
+# Tell apt-get we're never going to be able to give manual feedback:
+export DEBIAN_FRONTEND=noninteractive
+
+# Update the package listing, so we know what package exist:
+apt-get -y -qq -o=Dpkg::Use-Pty=0 update
+
+# Install security updates:
+apt-get -y -q -o=Dpkg::Use-Pty=0 upgrade
+
+# Install cURL (needed for Poetry install)
+apt-get -y -qq install --no-install-recommends -o=Dpkg::Use-Pty=0 curl
+
+# Install American English dict
+apt-get -y -qq install --no-install-recommends -o=Dpkg::Use-Pty=0 wamerican
+
+# Delete cached files we don't need anymore (note that if you're
+# using official Docker images for Debian or Ubuntu, this happens
+# automatically, you don't need to do it yourself):
+apt-get clean
+# Delete index files we don't need anymore:
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Since this project relies on `/usr/share/dict/american-english`, which does not exist on most Windows machines, I've dockerized it so that Windows users can run it in a container which does contain that directory.

Windows users will want to install Docker for Windows and ensure that the `docker` command is available in their terminal of choice, Powershell.

See readme for instructions.
